### PR TITLE
Added compatibility with logrus.WithError function; added tests

### DIFF
--- a/cloudlog_hook.go
+++ b/cloudlog_hook.go
@@ -21,6 +21,14 @@ type Hook struct {
 }
 
 var converterFunc = func(entry *logrus.Entry) interface{} {
+	if entry.Data["error"] != nil {
+		errorField, ok := entry.Data["error"].(error)
+		if ok {
+			entry.Data["error"] = errorField.Error()
+		}
+	}
+
+
 	d := document{
 		Fields:  entry.Data,
 		Message: entry.Message,

--- a/cloudlog_hook_test.go
+++ b/cloudlog_hook_test.go
@@ -4,6 +4,9 @@ import (
 	"testing"
 
 	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
+	"errors"
 )
 
 type MockCloudlogClient struct {
@@ -45,4 +48,50 @@ func TestHook(t *testing.T) {
 			t.Errorf("len is %v, expected %v", l, e.expected)
 		}
 	}
+}
+
+func TestHookWithField(t *testing.T) {
+	client := MockCloudlogClient{}
+	hook := NewCustomHook(&client, converterFunc, logrus.InfoLevel)
+	logrus.AddHook(hook)
+	logrus.SetLevel(logrus.InfoLevel)
+
+	logrus.WithField("key","value").Info("Message")
+
+	require.Len(t, client.events, 1, "event count missmatch")
+	event, ok := client.events[0].(document)
+	require.True(t, ok)
+	assert.EqualValues(t, "value", event.Fields["key"])
+	assert.EqualValues(t, "Message", event.Message)
+}
+
+func TestHookWithFields(t *testing.T) {
+        client := MockCloudlogClient{}
+        hook := NewCustomHook(&client, converterFunc, logrus.InfoLevel)
+        logrus.AddHook(hook)
+        logrus.SetLevel(logrus.InfoLevel)
+
+        logrus.WithFields(logrus.Fields{"key":"value"}).Info("Message")
+
+		require.Len(t, client.events, 1, "event count missmatch")
+        event, ok := client.events[0].(document)
+        require.True(t, ok)
+        assert.EqualValues(t, "value", event.Fields["key"])
+        assert.EqualValues(t, "Message", event.Message)
+}
+
+func TestHookWithError(t *testing.T) {
+	client := MockCloudlogClient{}
+	hook := NewCustomHook(&client, converterFunc, logrus.InfoLevel)
+	logrus.AddHook(hook)
+	logrus.SetLevel(logrus.InfoLevel)
+
+	logrus.WithError(errors.New("test error")).Error("Message")
+
+	require.Len(t, client.events, 1, "event count missmatch")
+	event, ok := client.events[0].(document)
+	require.True(t, ok)
+	assert.EqualValues(t, "test error", event.Fields["error"])
+	assert.EqualValues(t, "Message", event.Message)
+	assert.EqualValues(t, "error", event.Level)
 }


### PR DESCRIPTION
This PR introduces support for encoding errors provided via logrus' .WithError() function. If an error field exists on the provided entry, its' content is converted to the corresponding String and the value is replaced with the string.

Test cases are added to cover .WithField, .WithFields and .WithError

Signed-off-by: Roland Urbano <rurbano@anexia-it.com>